### PR TITLE
v0.10.5 Prevalence Sensitivity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TMLECLI"
 uuid = "2573d147-4098-46ba-9db2-8608d210ccac"
 authors = ["Olivier Labayle"]
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/cli.jl
+++ b/src/cli.jl
@@ -79,6 +79,15 @@ function cli_settings()
         "--prevalence"
             arg_type = Float64
             help = "Optional prevalence parameter for biased sampling designs (a probability between 0 and 1)."        
+
+        "--prevalence-range"
+            arg_type = String
+            help = "Optional prevalence range for sensitivity analysis (e.g., '0.006,0.013'). If provided, estimates are computed at multiple prevalence values."
+
+        "--n-prevalence-points"
+            arg_type = Int
+            default = 5
+            help = "Number of prevalence points within the range for sensitivity analysis (default: 5). Only used if --prevalence-range is provided."
     end
 
     @add_arg_table! s["merge"] begin
@@ -124,7 +133,9 @@ function julia_main()::Cint
                 sort_estimands=cmd_settings["sort-estimands"],
                 save_sample_ids=cmd_settings["save-sample-ids"],
                 pvalue_threshold=cmd_settings["pvalue-threshold"],
-                prevalence=cmd_settings["prevalence"]
+                prevalence=cmd_settings["prevalence"],
+                prevalence_range=cmd_settings["prevalence-range"],
+                n_prevalence_points=cmd_settings["n-prevalence-points"]
             )
         else
             make_summary(cmd_settings["prefix"];

--- a/src/models/registry.jl
+++ b/src/models/registry.jl
@@ -25,10 +25,10 @@ function GLM_CLASSIFIER(treatment_variables, interactions)
     return if interactions
         Pipeline(
             INTERACTION_TRANSFORMER(treatment_variables), 
-            LogisticClassifier(lambda=0.)
+            TMLE.LinearBinaryClassifier()
         )
     else
-        LogisticClassifier(lambda=0.)
+        TMLE.LinearBinaryClassifier()
     end
 end
 

--- a/src/models/registry.jl
+++ b/src/models/registry.jl
@@ -25,10 +25,10 @@ function GLM_CLASSIFIER(treatment_variables, interactions)
     return if interactions
         Pipeline(
             INTERACTION_TRANSFORMER(treatment_variables), 
-            TMLE.LinearBinaryClassifier()
+            LogisticClassifier(lambda=0.)
         )
     else
-        TMLE.LinearBinaryClassifier()
+        LogisticClassifier(lambda=0.)
     end
 end
 

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -4,6 +4,62 @@ function load_julia_estimators(file)
 end
 
 """
+    parse_prevalence_range(prevalence_range::AbstractString)
+
+Parse a prevalence range string "lower,upper" to a tuple (lower, upper).
+"""
+function parse_prevalence_range(prevalence_range::AbstractString)
+    parts = split(prevalence_range, ",")
+    if length(parts) != 2
+        throw(ArgumentError("prevalence-range must be in the format 'lower,upper' (e.g., '0.006,0.013')"))
+    end
+    lower = parse(Float64, strip(parts[1]))
+    upper = parse(Float64, strip(parts[2]))
+    if lower >= upper
+        throw(ArgumentError("Lower bound of prevalence range must be less than upper bound"))
+    end
+    if lower <= 0 || upper >= 1
+        throw(ArgumentError("Prevalence bounds must be between 0 and 1 (exclusive)"))
+    end
+    return (lower, upper)
+end
+
+parse_prevalence_range(::Nothing) = nothing
+
+"""
+    get_prevalence_grid(prevalence, prevalence_range, n_points)
+
+Construct a grid of prevalence values for sensitivity analysis.
+
+- If `prevalence_range` is nothing, return a single-element vector with `prevalence` (or nothing)
+- If `prevalence_range` is provided:
+  - Throw ArgumentError if `prevalence` is provided but outside the range
+  - Use `n_points` evenly spaced values within the range including the bounds
+  - Return sorted unique values
+"""
+function get_prevalence_grid(prevalence, prevalence_range::Nothing, n_points)
+    return [prevalence]
+end
+
+function get_prevalence_grid(prevalence, prevalence_range::Tuple{Float64, Float64}, n_points)
+    lower, upper = prevalence_range
+    
+    if !isnothing(prevalence) && (prevalence < lower || prevalence > upper)
+        throw(ArgumentError("Prevalence $prevalence is outside the specified range [$lower, $upper]"))
+    end
+    
+    # Create evenly spaced grid
+    grid = collect(range(lower, upper, length=n_points))
+    
+    # Add prevalence if provided and not already in grid
+    if !isnothing(prevalence)
+        push!(grid, prevalence)
+    end
+    
+    return sort(unique(grid))
+end
+
+"""
 If estimators is an AbstractString, it is either:
 
 - A Julia file containing a `ESTIMATORS` NamedTuple of these
@@ -124,7 +180,8 @@ function (runner::Runner)(partition)
     for (partition_index, param_index) in enumerate(partition)
         Ψ = runner.estimands[param_index]
         if skip_fast(runner, Ψ)
-            results[partition_index] = NamedTuple{keys(runner.estimators)}([FailedEstimate(Ψ, "Skipped due to shared failed nuisance fit.") for _ in 1:length(runner.estimators)])
+            skipped_result = NamedTuple{keys(runner.estimators)}([FailedEstimate(Ψ, "Skipped due to shared failed nuisance fit.") for _ in 1:length(runner.estimators)])
+            results[partition_index] = isnothing(runner.prevalence) ? skipped_result : merge(skipped_result, (PREVALENCE = runner.prevalence,))
             continue
         end
         # Make sure data types are appropriate for the estimand
@@ -138,8 +195,9 @@ function (runner::Runner)(partition)
                 TMLE.emptyIC(result, runner.pvalue_threshold)
             )
         end
-        # Update results
-        results[partition_index] = NamedTuple{keys(runner.estimators)}(estimators_results)
+        # Update results (add PREVALENCE field only for CCW-TMLE, i.e., when prevalence is specified)
+        estimator_results_nt = NamedTuple{keys(runner.estimators)}(estimators_results)
+        results[partition_index] = isnothing(runner.prevalence) ? estimator_results_nt : merge(estimator_results_nt, (PREVALENCE = runner.prevalence,))
         # Release cache
         release!(runner.cache_manager, Ψ)
         # Try clean C memory
@@ -151,9 +209,9 @@ function (runner::Runner)(partition)
     return results
 end
 
-function (runner::Runner)()
+function (runner::Runner)(;skip_init_finalize::Bool=false)
     # Initialize output files
-    initialize(runner.outputs)
+    skip_init_finalize || initialize(runner.outputs)
     # Run and update output files in batches
     nparams = size(runner.estimands, 1)
     for partition in Iterators.partition(1:nparams, runner.chunksize)
@@ -161,7 +219,7 @@ function (runner::Runner)()
         update_outputs(runner, results)
     end
     # Finalize output files
-    finalize(runner.outputs)
+    skip_init_finalize || finalize(runner.outputs)
 end
 
 
@@ -193,6 +251,9 @@ TMLE CLI.
 - `-r, --rng`: Random seed (Only used for estimands ordering at the moment).
 - `-c, --cache-strategy`: Caching Strategy for the nuisance functions, any of ("release-unusable", "no-cache", "max-size").
 - `--prevalence`: If the true prevalence of the outcome is known in the population, it can be specified here to correct for sampling bias.
+- `--prevalence-range`: Range of prevalence values for sensitivity analysis (e.g., "0.006,0.013").
+- `--n-prevalence-points`: Number of prevalence points within the range (default: 5).
+
 # Flags
 
 - `-s, --sort_estimands`: Sort estimands to minimize cache usage (A brute force approach will be used, resulting in exponentially long sorting time).
@@ -208,22 +269,42 @@ function tmle(dataset::String;
     sort_estimands::Bool=false,
     save_sample_ids=false,
     pvalue_threshold=nothing,
-    prevalence=nothing
+    prevalence=nothing,
+    prevalence_range=nothing,
+    n_prevalence_points::Int=5
     )
-    runner = Runner(dataset;
-        estimands_config=estimands, 
-        estimators_spec=estimators, 
-        verbosity=verbosity, 
-        outputs=outputs, 
-        chunksize=chunksize,
-        rng=rng,
-        cache_strategy=cache_strategy,
-        sort_estimands=sort_estimands,
-        save_sample_ids=save_sample_ids,
-        pvalue_threshold=pvalue_threshold,
-        prevalence=prevalence
-    )
-    runner()
+    # Parse prevalence range if provided
+    parsed_range = parse_prevalence_range(prevalence_range)
+    
+    # Get prevalence grid for sensitivity analysis
+    prevalence_grid = get_prevalence_grid(prevalence, parsed_range, n_prevalence_points)
+    
+    verbosity >= 1 && !isnothing(parsed_range) && @info "Running sensitivity analysis over $(length(prevalence_grid)) prevalence values: $prevalence_grid"
+    
+    initialize(outputs)
+    # If no prevalence is provided standard tmle is ran 
+    # If prevalence is specifed without range it will also run once with ccw-tmle
+    for (i, prev) in enumerate(prevalence_grid)
+        verbosity >= 1 && !isnothing(parsed_range) && @info "Estimating with prevalence = $prev ($(i)/$(length(prevalence_grid)))"
+        
+        runner = Runner(dataset;
+            estimands_config=estimands, 
+            estimators_spec=estimators, 
+            verbosity=verbosity, 
+            outputs=outputs, 
+            chunksize=chunksize,
+            rng=rng,
+            cache_strategy=cache_strategy,
+            sort_estimands=sort_estimands,
+            save_sample_ids=save_sample_ids,
+            pvalue_threshold=pvalue_threshold,
+            prevalence=prev
+        )
+        runner(;skip_init_finalize=true)
+    end
+    
+    finalize(outputs)
+    
     verbosity >= 1 && @info "Done."
     return
 end

--- a/test/models/registry.jl
+++ b/test/models/registry.jl
@@ -76,12 +76,12 @@ end
     for estimator in estimators
         Qbinary = estimator.models[:Q_binary_default].probabilistic_stack
         Qcontinuous = estimator.models[:Q_continuous_default].deterministic_stack
-        G = estimator.models[:G_default].linear_binary_classifier
+        G = estimator.models[:G_default].logistic_classifier
 
         @test Qbinary.glmnet.restricted_interaction_transformer.primary_variables_patterns == Regex[r"^Coco$"]
         @test Qbinary.glmnet.glm_net_classifier.resampling == expected_resampling
         @test Qbinary.lr.restricted_interaction_transformer.primary_variables_patterns == Regex[r"^Coco$"]
-        @test Qbinary.lr.linear_binary_classifier isa TMLE.LinearBinaryClassifier
+        @test Qbinary.lr.logistic_classifier isa MLJLinearModels.LogisticClassifier
         xgboost_hyperparams = map(1:12) do i
             xgboost = getproperty(Qbinary, Symbol(:xgboost_classifier_, i))
             xgboost.eta, xgboost.max_depth
@@ -98,7 +98,7 @@ end
         end
         @test allunique(xgboost_hyperparams)
 
-        @test G isa TMLE.LinearBinaryClassifier
+        @test G.logistic_classifier isa MLJLinearModels.LogisticClassifier
     end
 end
 

--- a/test/models/registry.jl
+++ b/test/models/registry.jl
@@ -76,12 +76,12 @@ end
     for estimator in estimators
         Qbinary = estimator.models[:Q_binary_default].probabilistic_stack
         Qcontinuous = estimator.models[:Q_continuous_default].deterministic_stack
-        G = estimator.models[:G_default].logistic_classifier
+        G = estimator.models[:G_default].linear_binary_classifier
 
         @test Qbinary.glmnet.restricted_interaction_transformer.primary_variables_patterns == Regex[r"^Coco$"]
         @test Qbinary.glmnet.glm_net_classifier.resampling == expected_resampling
         @test Qbinary.lr.restricted_interaction_transformer.primary_variables_patterns == Regex[r"^Coco$"]
-        @test Qbinary.lr.logistic_classifier isa MLJLinearModels.LogisticClassifier
+        @test Qbinary.lr.linear_binary_classifier isa TMLE.LinearBinaryClassifier
         xgboost_hyperparams = map(1:12) do i
             xgboost = getproperty(Qbinary, Symbol(:xgboost_classifier_, i))
             xgboost.eta, xgboost.max_depth
@@ -98,7 +98,7 @@ end
         end
         @test allunique(xgboost_hyperparams)
 
-        @test G isa LogisticClassifier
+        @test G isa TMLE.LinearBinaryClassifier
     end
 end
 

--- a/test/models/registry.jl
+++ b/test/models/registry.jl
@@ -98,7 +98,7 @@ end
         end
         @test allunique(xgboost_hyperparams)
 
-        @test G.logistic_classifier isa MLJLinearModels.LogisticClassifier
+        @test G isa MLJLinearModels.LogisticClassifier
     end
 end
 

--- a/test/runner.jl
+++ b/test/runner.jl
@@ -352,6 +352,154 @@ end
     @test differ
 end
 
+@testset "Test get_prevalence_grid" begin
+    # Test with no range - returns single prevalence
+    @test TMLECLI.get_prevalence_grid(0.01, nothing, 5) == [0.01]
+    @test TMLECLI.get_prevalence_grid(nothing, nothing, 5) == [nothing]
+    
+    # Test with range and no point prevalence
+    grid = TMLECLI.get_prevalence_grid(nothing, (0.006, 0.013), 5)
+    @test length(grid) == 5
+    @test grid[1] ≈ 0.006
+    @test grid[end] ≈ 0.013
+    
+    # Test with range and point prevalence within range
+    grid = TMLECLI.get_prevalence_grid(0.01, (0.006, 0.013), 5)
+    @test 0.01 ∈ grid  # primary prevalence included
+    @test grid[1] ≈ 0.006  # lower bound included
+    @test grid[end] ≈ 0.013  # upper bound included
+    
+    # Test prevalence outside range throws error
+    @test_throws ArgumentError TMLECLI.get_prevalence_grid(0.005, (0.006, 0.013), 5)
+    @test_throws ArgumentError TMLECLI.get_prevalence_grid(0.02, (0.006, 0.013), 5)
+end
+
+@testset "Test parse_prevalence_range" begin
+    # Valid range
+    @test TMLECLI.parse_prevalence_range("0.006,0.013") == (0.006, 0.013)
+    @test TMLECLI.parse_prevalence_range(" 0.006 , 0.013 ") == (0.006, 0.013)  # with whitespace
+    
+    # Invalid formats
+    @test_throws ArgumentError TMLECLI.parse_prevalence_range("0.006")  # missing upper
+    @test_throws ArgumentError TMLECLI.parse_prevalence_range("0.013,0.006")  # lower >= upper
+    @test_throws ArgumentError TMLECLI.parse_prevalence_range("0,0.013")  # lower <= 0
+    @test_throws ArgumentError TMLECLI.parse_prevalence_range("0.006,1")  # upper >= 1
+    
+    # Nothing returns nothing
+    @test TMLECLI.parse_prevalence_range(nothing) === nothing
+end
+
+@testset "Test tmle: prevalence sensitivity analysis" begin
+    tmpdir = mktempdir()
+    datafile = joinpath(tmpdir, "data.csv")
+    write_dataset(datafile)
+    estimandsfile = joinpath(tmpdir, "configuration.json")
+    configuration = binary_statistical_estimands_config()
+    TMLE.write_json(estimandsfile, configuration)
+
+    # Run with prevalence range for sensitivity analysis
+    jls_output = joinpath(tmpdir, "output_sensitivity.jls")
+    hdf5_output = joinpath(tmpdir, "output_sensitivity.hdf5")
+    json_output = joinpath(tmpdir, "output_sensitivity.json")
+    
+    copy!(ARGS, [
+        "tmle",
+        datafile,
+        "--estimands", estimandsfile,
+        "--estimators=tmle--glm",
+        "--prevalence=0.10",
+        "--prevalence-range=0.05,0.15",
+        "--n-prevalence-points=3",
+        "--json-output", json_output,
+        "--hdf5-output", hdf5_output,
+        "--jls-output", jls_output
+    ])
+    TMLECLI.julia_main()
+
+    results = []
+    open(jls_output) do io
+        while !eof(io)
+            push!(results, deserialize(io))
+        end
+    end
+    
+    # Should have results for multiple prevalence values
+    # With n_prevalence_points=3 and prevalence=0.10 within range [0.05, 0.15]
+    @test length(results) == 3
+    
+    # Each result should have PREVALENCE field
+    @test all(haskey(r, :PREVALENCE) for r in results)
+    
+    # Check that all prevalence values in the grid are present
+    prevalences = [r[:PREVALENCE] for r in results]
+    @test 0.10 ∈ prevalences  # prevalence
+    @test 0.05 ∈ prevalences  # lower bound
+    @test 0.15 ∈ prevalences  # upper bound
+    
+    # All estimates should be TMLEstimates or FailedEstimates
+    for res in results
+        @test isa(res[:TMLE_GLM_GLM], TMLE.TMLEstimate) || isa(res[:TMLE_GLM_GLM], TMLECLI.FailedEstimate)
+    end
+    
+    # Successful estimates at different prevalences should be distinguishable (not identical)
+    successful_results = filter(r -> isa(r[:TMLE_GLM_GLM], TMLE.TMLEstimate), results)
+    if length(successful_results) > 1
+        estimates = [r[:TMLE_GLM_GLM].estimate for r in successful_results]
+        @test length(unique(estimates)) > 1  # At least some estimates should differ
+    end
+    
+    # Verify HDF5 output also contains PREVALENCE
+    hdf5_results = jldopen(hdf5_output) do io
+        vcat([io[key] for key in keys(io)]...)
+    end
+    @test all(haskey(r, :PREVALENCE) for r in hdf5_results)
+    @test length(hdf5_results) == 3
+    
+    # Verify JSON output also contains PREVALENCE
+    json_results = TMLE.read_json(json_output, use_mmap=false)
+    @test all(haskey(r, :PREVALENCE) for r in json_results)
+    @test length(json_results) == 3
+end
+
+@testset "Test tmle: prevalence sensitivity without prevalence option" begin
+    tmpdir = mktempdir()
+    datafile = joinpath(tmpdir, "data.csv")
+    write_dataset(datafile)
+    estimandsfile = joinpath(tmpdir, "configuration.json")
+    configuration = binary_statistical_estimands_config()
+    TMLE.write_json(estimandsfile, configuration)
+
+    # Run with prevalence range only (no --prevalence)
+    jls_output = joinpath(tmpdir, "output_range_only.jls")
+    
+    copy!(ARGS, [
+        "tmle",
+        datafile,
+        "--estimands", estimandsfile,
+        "--estimators=tmle--glm",
+        "--prevalence-range=0.05,0.15",
+        "--n-prevalence-points=3",
+        "--jls-output", jls_output
+    ])
+    TMLECLI.julia_main()
+
+    # Load results
+    results = []
+    open(jls_output) do io
+        while !eof(io)
+            push!(results, deserialize(io))
+        end
+    end
+    
+    # Should have exactly 3 results (n_prevalence_points=3, 1 estimand)
+    @test length(results) == 3
+    
+    # Check prevalence values
+    prevalences = [r[:PREVALENCE] for r in results]
+    @test 0.05 ∈ prevalences
+    @test 0.15 ∈ prevalences
+end
+
 end;
 
 true


### PR DESCRIPTION
In applying certain prevalence estimates to the case-control weighted TMLE, one may be interested in knowing how the choice of the prevalence parameter impacts estimation. In this update, I add a non-breaking change that allows for users to specify a range of prevalence parameters to be estimated. This has real-world/research applications as in epidemiology, reports may cite prevalence as a range and it would be insightful to know if the bounds of the range provide different interpretations of our population parameter estimates.

